### PR TITLE
Add pyproject.toml for pip-installable packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 .DS_Store
 .ipynb_checkpoints
 __pycache__
+*.egg-info
+build/
+dist/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,35 @@
+[build-system]
+requires = ["setuptools>=64"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "taehv"
+version = "0.1.0"
+description = "Tiny AutoEncoder for Hunyuan Video (and other video models)"
+readme = "README.md"
+license = "MIT"
+requires-python = ">=3.8"
+authors = [
+    {name = "Ollin Boer Bohan"},
+]
+keywords = ["autoencoder", "video", "hunyuan", "wan", "diffusion"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Science/Research",
+    "Programming Language :: Python :: 3",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+]
+dependencies = [
+    "torch",
+    "tqdm",
+]
+
+[project.urls]
+Homepage = "https://github.com/madebyollin/taehv"
+Repository = "https://github.com/madebyollin/taehv"
+
+[project.scripts]
+taehv = "taehv:main"
+
+[tool.setuptools]
+py-modules = ["taehv"]


### PR DESCRIPTION
Exposed the existing taehv.py as a top-level module.
Adds a pyproject.toml so taehv can be installed as a proper Python package.

`pip install git+https://github.com/madebyollin/taehv.git`

```from taehv import TAEHV
ae = TAEHV("taehv1_5.pth")```