### PR TITLE
Optimized decoder [WIP]

### DIFF
--- a/taehv.py
+++ b/taehv.py
@@ -483,16 +483,15 @@ class TAEHV(nn.Module):
         return x[:, self.frames_to_trim:]
 
 class StreamingOptDecoder(nn.Module):
-    def __init__(self, taehv):
+    def __init__(self, taehv, device='cuda', dtype=torch.float16, input_shape=(32, 64)):
         super().__init__()
 
-        self.decoder = OptimizedDecoder()
-        self.feat_cache = FeatCache()
-        self.decoder.from_taehv(taehv)
+        self.decoder = OptimizedDecoder.from_taehv(taehv)
+        self.feat_cache = FeatCache(device=device, dtype=dtype, input_shape=input_shape)
 
     def reset(self):
         self.feat_cache.reset()
-    
+
     def decode(self, x): # assumes x is [1,1,c,h,w]
         return self.decoder(x.squeeze(1), self.feat_cache)
 

--- a/taehv.py
+++ b/taehv.py
@@ -7,7 +7,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from tqdm.auto import tqdm
-from collections import namedtuple
+from collections import namedtuple, deque
 
 TWorkItem = namedtuple("TWorkItem", ("input_tensor", "block_index"))
 
@@ -77,7 +77,7 @@ def apply_model_with_memblocks_parallel(model, x, show_progress_bar):
     T = NT // N
     return x.view(N, T, C, H, W)
 
-def apply_model_with_memblocks_sequential_single_step(model, memory, work_queue, progress_bar=None):
+def apply_model_with_memblocks_sequential_single_step(model, memory, work_queue, progress_bar=None, layer_types=None):
     """
     Process the work queue (a graph traversal over blocks and timesteps)
     until an output frame is produced or the queue is empty.
@@ -86,21 +86,22 @@ def apply_model_with_memblocks_sequential_single_step(model, memory, work_queue,
     Returns N1CHW output tensor, or None if the queue needs more input.
     """
     while work_queue:
-        xt, i = work_queue.pop(0)
+        xt, i = work_queue.popleft()
         if progress_bar is not None and i == 0:
             progress_bar.update(1)
         if i == len(model):
             return xt.unsqueeze(1)
         b = model[i]
-        if isinstance(b, MemBlock):
+        btype = layer_types[i] if layer_types is not None else type(b)
+        if btype is MemBlock:
             # mem blocks are simple since we're visiting the graph in causal order
             if memory[i] is None:
-                xt_new = b(xt, xt * 0)
+                xt_new = b(xt, torch.zeros_like(xt))
             else:
                 xt_new = b(xt, memory[i])
             memory[i] = xt
-            work_queue.insert(0, TWorkItem(xt_new, i+1))
-        elif isinstance(b, TPool):
+            work_queue.appendleft(TWorkItem(xt_new, i+1))
+        elif btype is TPool:
             # pool blocks accumulate inputs until they have enough to pool
             if memory[i] is None:
                 memory[i] = []
@@ -111,15 +112,15 @@ def apply_model_with_memblocks_sequential_single_step(model, memory, work_queue,
                 N, C, H, W = xt.shape
                 xt = b(torch.cat(memory[i], 1).view(N*b.stride, C, H, W))
                 memory[i] = []
-                work_queue.insert(0, TWorkItem(xt, i+1))
-        elif isinstance(b, TGrow):
+                work_queue.appendleft(TWorkItem(xt, i+1))
+        elif btype is TGrow:
             xt = b(xt)
             NT, C, H, W = xt.shape
             for xt_next in reversed(xt.view(NT//b.stride, b.stride*C, H, W).chunk(b.stride, 1)):
-                work_queue.insert(0, TWorkItem(xt_next, i+1))
+                work_queue.appendleft(TWorkItem(xt_next, i+1))
         else:
             xt = b(xt)
-            work_queue.insert(0, TWorkItem(xt, i+1))
+            work_queue.appendleft(TWorkItem(xt, i+1))
     return None
 
 def apply_model_with_memblocks_sequential(model, x, show_progress_bar):
@@ -135,7 +136,7 @@ def apply_model_with_memblocks_sequential(model, x, show_progress_bar):
     Returns NTCHW tensor of output data.
     """
     assert x.ndim == 5, f"TAEHV operates on NTCHW tensors, but got {x.ndim}-dim tensor"
-    work_queue = [TWorkItem(xt, 0) for xt in x.unbind(1)]
+    work_queue = deque(TWorkItem(xt, 0) for xt in x.unbind(1))
     memory = [None] * len(model)
     progress_bar = tqdm(range(len(work_queue)), disable=not show_progress_bar)
     out = []
@@ -299,12 +300,14 @@ class StreamingTAEHV(nn.Module):
         """
         super().__init__()
         self.taehv = taehv
+        self.encoder_layer_types = [type(b) for b in taehv.encoder]
+        self.decoder_layer_types = [type(b) for b in taehv.decoder]
         self.reset()
 
     def reset(self):
         """Reset all internal state. Call this to start encoding/decoding a new stream."""
-        self.encoder_work_queue, self.encoder_memory = [], [None] * len(self.taehv.encoder)
-        self.decoder_work_queue, self.decoder_memory = [], [None] * len(self.taehv.decoder)
+        self.encoder_work_queue, self.encoder_memory = deque(), [None] * len(self.taehv.encoder)
+        self.decoder_work_queue, self.decoder_memory = deque(), [None] * len(self.taehv.decoder)
         self.n_frames_encoded, self.n_frames_decoded = 0, 0
         self._last_encoder_input_frame = None
 
@@ -326,7 +329,8 @@ class StreamingTAEHV(nn.Module):
             self.encoder_work_queue.extend(TWorkItem(xt, 0) for xt in x.unbind(1))
             self.n_frames_encoded += x.shape[1]
         xt = apply_model_with_memblocks_sequential_single_step(
-            self.taehv.encoder, self.encoder_memory, self.encoder_work_queue)
+            self.taehv.encoder, self.encoder_memory, self.encoder_work_queue,
+            layer_types=self.encoder_layer_types)
         return xt
 
     def decode(self, x=None):
@@ -349,7 +353,8 @@ class StreamingTAEHV(nn.Module):
             self.decoder_work_queue.extend(TWorkItem(xt, 0) for xt in x.unbind(1))
         while True:
             xt = apply_model_with_memblocks_sequential_single_step(
-                self.taehv.decoder, self.decoder_memory, self.decoder_work_queue)
+                self.taehv.decoder, self.decoder_memory, self.decoder_work_queue,
+                layer_types=self.decoder_layer_types)
             if xt is None:
                 return None
             self.n_frames_decoded += 1

--- a/taehv.py
+++ b/taehv.py
@@ -198,7 +198,7 @@ def apply_model_with_memblocks(model, x, parallel, show_progress_bar):
         return apply_model_with_memblocks_sequential(model, x, show_progress_bar)
 
 class FeatCache:
-    def __init__(self, input_shape=[32,64], device, dtype):
+    def __init__(self, device='cuda', dtype=torch.bfloat16, input_shape=[32,64]):
         self.cache = {}
         self.device = device
         self.dtype = dtype
@@ -211,15 +211,15 @@ class FeatCache:
     
     def reset(self):
         self.cache = {
-            "00" : get_tensor(1, self.n_f[0], self.h, self.w),
-            "01" : get_tensor(1, self.n_f[0], self.h, self.w),
-            "02" : get_tensor(1, self.n_f[0], self.h, self.w),
-            "10" : get_tensor(1, self.n_f[1], self.h*2, self.w*2),
-            "11" : get_tensor(1, self.n_f[1], self.h*2, self.w*2),
-            "12" : get_tensor(1, self.n_f[1], self.h*2, self.w*2),
-            "20" : get_tensor(1, self.n_f[2], self.h*4, self.w*4),
-            "21" : get_tensor(1, self.n_f[2], self.h*4, self.w*4),
-            "22" : get_tensor(1, self.n_f[2], self.h*4, self.w*4),
+            "00" : self.get_tensor(1, self.n_f[0], self.h, self.w),
+            "01" : self.get_tensor(1, self.n_f[0], self.h, self.w),
+            "02" : self.get_tensor(1, self.n_f[0], self.h, self.w),
+            "10" : self.get_tensor(1, self.n_f[1], self.h*2, self.w*2),
+            "11" : self.get_tensor(1, self.n_f[1], self.h*2, self.w*2),
+            "12" : self.get_tensor(1, self.n_f[1], self.h*2, self.w*2),
+            "20" : self.get_tensor(1, self.n_f[2], self.h*4, self.w*4),
+            "21" : self.get_tensor(1, self.n_f[2], self.h*4, self.w*4),
+            "22" : self.get_tensor(1, self.n_f[2], self.h*4, self.w*4),
         }
     
     def get(self, key):
@@ -371,8 +371,6 @@ class OptimizedDecoder(nn.Module):
         y = F.pixel_shuffle(y, self.patch_size)
         return y.clamp_(0, 1)
 
-
-
 class TAEHV(nn.Module):
     def __init__(self, checkpoint_path="taehv.pth", encoder_time_downscale=(True, True, False), decoder_time_upscale=(False, True, True), decoder_space_upscale=(True, True, True), patch_size=1, latent_channels=16):
         """Initialize pretrained TAEHV from the given checkpoint.
@@ -483,6 +481,20 @@ class TAEHV(nn.Module):
             # (cogvideox seems to pad at the start?), but for multiple-of-4 it's fine.
             return x
         return x[:, self.frames_to_trim:]
+
+class StreamingOptDecoder(nn.Module):
+    def __init__(self, taehv):
+        super().__init__()
+
+        self.decoder = OptimizedDecoder()
+        self.feat_cache = FeatCache()
+        self.decoder.from_taehv(taehv)
+
+    def reset(self):
+        self.feat_cache.reset()
+    
+    def decode(self, x): # assumes x is [1,1,c,h,w]
+        return self.decoder(x.squeeze(1), self.feat_cache)
 
 class StreamingTAEHV(nn.Module):
     def __init__(self, taehv):

--- a/taehv.py
+++ b/taehv.py
@@ -24,6 +24,14 @@ class MemBlock(nn.Module):
         self.conv = nn.Sequential(conv(n_in * 2, n_out), nn.ReLU(inplace=True), conv(n_out, n_out), nn.ReLU(inplace=True), conv(n_out, n_out))
         self.skip = nn.Conv2d(n_in, n_out, 1, bias=False) if n_in != n_out else nn.Identity()
         self.act = nn.ReLU(inplace=True)
+    
+    def pair_forward(self, x, y):
+        """
+        Conceptually, x is past, y is future
+        information flows into the future state
+        """
+        return self.act(self.conv(torch.cat([y, x], 1)) + self.skip(y))
+
     def forward(self, x, past):
         return self.act(self.conv(torch.cat([x, past], 1)) + self.skip(x))
 
@@ -32,6 +40,7 @@ class TPool(nn.Module):
         super().__init__()
         self.stride = stride
         self.conv = nn.Conv2d(n_f*stride,n_f, 1, bias=False)
+
     def forward(self, x):
         _NT, C, H, W = x.shape
         return self.conv(x.reshape(-1, self.stride * C, H, W))
@@ -41,10 +50,34 @@ class TGrow(nn.Module):
         super().__init__()
         self.stride = stride
         self.conv = nn.Conv2d(n_f, n_f*stride, 1, bias=False)
+
     def forward(self, x):
         _NT, C, H, W = x.shape
         x = self.conv(x)
         return x.reshape(-1, C, H, W)
+
+class OptMemBlock1x(MemBlock):
+    def forward(self, x0, x1):
+        # x is bnchw
+        return self.pair_forward(x0, x1)
+
+class OptMemBlock2x(MemBlock):
+    def forward(self, x0, x1, x2):
+        # x is bnchw, we assume b is 1
+        past = torch.cat([x0, x1], 0)
+        future = torch.cat([x1, x2], 0)
+        y = self.pair_forward(past, future)
+        y1 = y[:1]
+        y2 = y[1:]
+        return y1, y2
+
+class OptTGrow(TGrow):
+    def forward(self, x):
+        # bchw
+        n,c,h,w = x.shape
+        x = self.conv(x) # -> b(2c)hw
+        x = x.reshape(n, 2, c, h, w)
+        return x.unbind(1)
 
 def apply_model_with_memblocks_parallel(model, x, show_progress_bar):
     """
@@ -163,6 +196,182 @@ def apply_model_with_memblocks(model, x, parallel, show_progress_bar):
         return apply_model_with_memblocks_parallel(model, x, show_progress_bar)
     else:
         return apply_model_with_memblocks_sequential(model, x, show_progress_bar)
+
+class FeatCache:
+    def __init__(self, input_shape=[32,64], device, dtype):
+        self.cache = {}
+        self.device = device
+        self.dtype = dtype
+        self.h, self.w = input_shape
+        self.n_f = [256, 128, 64, 64]
+        self.reset()
+    
+    def get_tensor(self, *shape):
+        return torch.zeros(shape, device=self.device, dtype=self.dtype)
+    
+    def reset(self):
+        self.cache = {
+            "00" : get_tensor(1, self.n_f[0], self.h, self.w),
+            "01" : get_tensor(1, self.n_f[0], self.h, self.w),
+            "02" : get_tensor(1, self.n_f[0], self.h, self.w),
+            "10" : get_tensor(1, self.n_f[1], self.h*2, self.w*2),
+            "11" : get_tensor(1, self.n_f[1], self.h*2, self.w*2),
+            "12" : get_tensor(1, self.n_f[1], self.h*2, self.w*2),
+            "20" : get_tensor(1, self.n_f[2], self.h*4, self.w*4),
+            "21" : get_tensor(1, self.n_f[2], self.h*4, self.w*4),
+            "22" : get_tensor(1, self.n_f[2], self.h*4, self.w*4),
+        }
+    
+    def get(self, key):
+        return self.cache[key]
+    
+    def set(self, key, value):
+        self.cache[key] = value.clone()
+
+def cat_fwd_split(layer, x, y):
+    z = torch.cat([x, y], 0)
+    z = layer(z)
+    return z.split(1, dim = 0)
+    
+class OptimizedDecoder(nn.Module):
+    def __init__(self):
+        super().__init__()
+
+        n_f = [256, 128, 64, 64]
+        self.latent_channels = 32
+        self.patch_size = 2
+        self.image_channels = 3
+
+        self.dec_pre = nn.Sequential(
+            Clamp(), conv(self.latent_channels, n_f[0]), nn.ReLU(inplace=True),
+        )
+
+        self.mb_00 = OptMemBlock1x(n_f[0], n_f[0])
+        self.mb_01 = OptMemBlock1x(n_f[0], n_f[0])
+        self.mb_02 = OptMemBlock1x(n_f[0], n_f[0])
+        self.up_0 = nn.Upsample(scale_factor=2)
+        self.proj_0 = conv(n_f[0], n_f[1], bias=False)
+
+        self.mb_10 = OptMemBlock1x(n_f[1], n_f[1])
+        self.mb_11 = OptMemBlock1x(n_f[1], n_f[1])
+        self.mb_12 = OptMemBlock1x(n_f[1], n_f[1])
+        self.up_1 = nn.Upsample(scale_factor=2)
+        self.t_up_1 = OptTGrow(n_f[1], 2)
+        self.proj_1 = conv(n_f[1], n_f[2], bias=False)
+
+        self.mb_20 = OptMemBlock2x(n_f[2], n_f[2])
+        self.mb_21 = OptMemBlock2x(n_f[2], n_f[2])
+        self.mb_22 = OptMemBlock2x(n_f[2], n_f[2])
+        self.up_2 = nn.Upsample(scale_factor=2)
+        self.t_up_2 = OptTGrow(n_f[2], 2)
+        self.proj_2 = conv(n_f[2], n_f[3], bias=False)
+
+        self.dec_post = nn.Sequential(
+            nn.ReLU(inplace=True), conv(n_f[3], self.image_channels * self.patch_size**2),
+        )
+
+    @classmethod
+    def from_taehv(cls, taehv):
+        """Create an OptimizedDecoder with weights copied from a TAEHV instance.
+
+        Assumes the TAEHV decoder has decoder_time_upscale=(False, True, True) and
+        decoder_space_upscale=(True, True, True), i.e. the taehv1_5 configuration.
+        The stride-1 TGrow at decoder[7] is dropped (it has no temporal effect).
+
+        TAEHV decoder layout (indices):
+          0:Clamp  1:conv  2:ReLU
+          3:MB  4:MB  5:MB  6:Upsample  7:TGrow(stride=1)[dropped]  8:conv
+          9:MB  10:MB  11:MB  12:Upsample  13:TGrow(stride=2)  14:conv
+          15:MB  16:MB  17:MB  18:Upsample  19:TGrow(stride=2)  20:conv
+          21:ReLU  22:conv
+        """
+        opt = cls()
+        dec = taehv.decoder
+
+        opt.dec_pre[1].load_state_dict(dec[1].state_dict())   # conv(latent→256)
+
+        opt.mb_00.load_state_dict(dec[3].state_dict())
+        opt.mb_01.load_state_dict(dec[4].state_dict())
+        opt.mb_02.load_state_dict(dec[5].state_dict())
+        # dec[6] = Upsample (no params), dec[7] = TGrow(stride=1) (dropped)
+        opt.proj_0.load_state_dict(dec[8].state_dict())       # conv(256→128)
+
+        opt.mb_10.load_state_dict(dec[9].state_dict())
+        opt.mb_11.load_state_dict(dec[10].state_dict())
+        opt.mb_12.load_state_dict(dec[11].state_dict())
+        # dec[12] = Upsample (no params)
+        opt.t_up_1.load_state_dict(dec[13].state_dict())      # TGrow(128, stride=2)
+        opt.proj_1.load_state_dict(dec[14].state_dict())      # conv(128→64)
+
+        opt.mb_20.load_state_dict(dec[15].state_dict())
+        opt.mb_21.load_state_dict(dec[16].state_dict())
+        opt.mb_22.load_state_dict(dec[17].state_dict())
+        # dec[18] = Upsample (no params)
+        opt.t_up_2.load_state_dict(dec[19].state_dict())      # TGrow(64, stride=2)
+        opt.proj_2.load_state_dict(dec[20].state_dict())      # conv(64→64)
+
+        opt.dec_post[1].load_state_dict(dec[22].state_dict()) # conv(64→out)
+
+        return opt
+
+    def forward(self, z, feat_cache):
+        # z is [1, c, h, w]
+        x0 = self.dec_pre(z)
+
+        # First stage
+        x1 = self.mb_00(feat_cache.get("00"), x0)
+        x2 = self.mb_01(feat_cache.get("01"), x1)
+        x3 = self.mb_02(feat_cache.get("02"), x2)
+
+        # Update cache
+        feat_cache.set("00", x0)
+        feat_cache.set("01", x1)
+        feat_cache.set("02", x2)
+
+        # Upsample and project
+        x4 = self.proj_0(self.up_0(x3))
+
+        # Second stage
+        x5 = self.mb_10(feat_cache.get("10"), x4)
+        x6 = self.mb_11(feat_cache.get("11"), x5)
+        x7 = self.mb_12(feat_cache.get("12"), x6)
+
+        # Update cache
+        feat_cache.set("10", x4)
+        feat_cache.set("11", x5)
+        feat_cache.set("12", x6)
+
+        # Upsample and project
+        x8 = self.up_1(x7)
+        x8_prev, x8_next = self.t_up_1(x8)
+        x9_prev = self.proj_1(x8_prev)
+        x9_next = self.proj_1(x8_next)
+
+        # Third stage
+        x10_prev, x10_next = self.mb_20(feat_cache.get("20"), x9_prev, x9_next)
+        x11_prev, x11_next = self.mb_21(feat_cache.get("21"), x10_prev, x10_next)
+        x12_prev, x12_next = self.mb_22(feat_cache.get("22"), x11_prev, x11_next)
+
+        # Update cache
+        feat_cache.set("20", x9_next)
+        feat_cache.set("21", x10_next)
+        feat_cache.set("22", x11_next)
+
+        # Upsample and project
+        x13_prev = self.up_2(x12_prev)
+        x13_next = self.up_2(x12_next)
+        
+        # Final stage, mostly just projections, no cache
+        y_0, y_1 = self.t_up_2(x13_prev)
+        y_2, y_3 = self.t_up_2(x13_next)
+
+        y = torch.cat([y_0, y_1, y_2, y_3], 0)
+        y = self.proj_2(y)
+        y = self.dec_post(y)
+        y = F.pixel_shuffle(y, self.patch_size)
+        return y.clamp_(0, 1)
+
+
 
 class TAEHV(nn.Module):
     def __init__(self, checkpoint_path="taehv.pth", encoder_time_downscale=(True, True, False), decoder_time_upscale=(False, True, True), decoder_space_upscale=(True, True, True), patch_size=1, latent_channels=16):

--- a/taehv.py
+++ b/taehv.py
@@ -250,6 +250,7 @@ class OptimizedDecoder(nn.Module):
         self.mb_01 = OptMemBlock1x(n_f[0], n_f[0])
         self.mb_02 = OptMemBlock1x(n_f[0], n_f[0])
         self.up_0 = nn.Upsample(scale_factor=2)
+        self.t_up_0 = TGrow(n_f[0], 1)
         self.proj_0 = conv(n_f[0], n_f[1], bias=False)
 
         self.mb_10 = OptMemBlock1x(n_f[1], n_f[1])
@@ -329,7 +330,7 @@ class OptimizedDecoder(nn.Module):
         feat_cache.set("02", x2)
 
         # Upsample and project
-        x4 = self.proj_0(self.up_0(x3))
+        x4 = self.proj_0(self.t_up_0(self.up_0(x3)))
 
         # Second stage
         x5 = self.mb_10(feat_cache.get("10"), x4)
@@ -492,6 +493,7 @@ class StreamingOptDecoder(nn.Module):
     def reset(self):
         self.feat_cache.reset()
 
+    #@torch.compile(mode='max-autotune', fullgraph=True)
     def decode(self, x): # assumes x is [1,1,c,h,w]
         return self.decoder(x.squeeze(1), self.feat_cache)
 

--- a/taehv.py
+++ b/taehv.py
@@ -321,23 +321,31 @@ class OptimizedDecoder(nn.Module):
 
         return opt
 
-    #@torch.compile(mode='max-autotune', fullgraph=True)
-    def forward_(self, z, c00, c01, c02, c10, c11, c12, c20, c21, c22):
+    @torch.compile(mode='max-autotune', fullgraph=True)
+    def forward(self, z, feat_cache):
         # z is [1, c, h, w]
         x0 = self.dec_pre(z)
 
         # First stage
-        x1 = self.mb_00(c00, x0)
-        x2 = self.mb_01(c01, x1)
-        x3 = self.mb_02(c02, x2)
+        x1 = self.mb_00(feat_cache.get("00"), x0)
+        x2 = self.mb_01(feat_cache.get("01"), x1)
+        x3 = self.mb_02(feat_cache.get("02"), x2)
+
+        feat_cache.set("00", x0)
+        feat_cache.set("01", x1)
+        feat_cache.set("02", x2)
 
         # Upsample and project
         x4 = self.proj_0(self.t_up_0(self.up_0(x3)))
 
         # Second stage
-        x5 = self.mb_10(c10, x4)
-        x6 = self.mb_11(c11, x5)
-        x7 = self.mb_12(c12, x6)
+        x5 = self.mb_10(feat_cache.get("10"), x4)
+        x6 = self.mb_11(feat_cache.get("11"), x5)
+        x7 = self.mb_12(feat_cache.get("12"), x6)
+
+        feat_cache.set("10", x4)
+        feat_cache.set("11", x5)
+        feat_cache.set("12", x6)
 
         # Upsample and project
         x8 = self.up_1(x7)
@@ -346,9 +354,13 @@ class OptimizedDecoder(nn.Module):
         x9_next = self.proj_1(x8_next)
 
         # Third stage
-        x10_prev, x10_next = self.mb_20(c20, x9_prev, x9_next)
-        x11_prev, x11_next = self.mb_21(c21, x10_prev, x10_next)
-        x12_prev, x12_next = self.mb_22(c22, x11_prev, x11_next)
+        x10_prev, x10_next = self.mb_20(feat_cache.get("20"), x9_prev, x9_next)
+        x11_prev, x11_next = self.mb_21(feat_cache.get("21"), x10_prev, x10_next)
+        x12_prev, x12_next = self.mb_22(feat_cache.get("22"), x11_prev, x11_next)
+
+        feat_cache.set("20", x9_next)
+        feat_cache.set("21", x10_next)
+        feat_cache.set("22", x11_next)
 
         # Upsample and project
         x13_prev = self.up_2(x12_prev)
@@ -362,29 +374,7 @@ class OptimizedDecoder(nn.Module):
         y = self.proj_2(y)
         y = self.dec_post(y)
         y = F.pixel_shuffle(y, self.patch_size)
-        return y.clamp_(0, 1), x0, x1, x2, x4, x5, x6, x9_next, x10_next, x11_next
-
-    def forward(self, z, feat_cache):
-        c00 = feat_cache.get("00")
-        c01 = feat_cache.get("01")
-        c02 = feat_cache.get("02")
-        c10 = feat_cache.get("10")
-        c11 = feat_cache.get("11")
-        c12 = feat_cache.get("12")
-        c20 = feat_cache.get("20")
-        c21 = feat_cache.get("21")
-        c22 = feat_cache.get("22")
-        y, c00, c01, c02, c10, c11, c12, c20, c21, c22 = self.forward_(z, c00, c01, c02, c10, c11, c12, c20, c21, c22)
-        feat_cache.set("00", c00)
-        feat_cache.set("01", c01)
-        feat_cache.set("02", c02)
-        feat_cache.set("10", c10)
-        feat_cache.set("11", c11)
-        feat_cache.set("12", c12)
-        feat_cache.set("20", c20)
-        feat_cache.set("21", c21)
-        feat_cache.set("22", c22)
-        return y
+        return y.clamp_(0, 1)
 
 class TAEHV(nn.Module):
     def __init__(self, checkpoint_path="taehv.pth", encoder_time_downscale=(True, True, False), decoder_time_upscale=(False, True, True), decoder_space_upscale=(True, True, True), patch_size=1, latent_channels=16):
@@ -508,12 +498,9 @@ class StreamingOptDecoder(nn.Module):
         self.feat_cache.reset()
 
     #@torch.compile(mode='max-autotune', fullgraph=True)
-    def decode_(self, x, feat_cache): # assumes x is [1,1,c,h,w]
-        return self.decoder(x.squeeze(1), feat_cache)
-
-    def decode(self, x):
+    def decode(self, x): # assumes x is [1,1,c,h,w]
         self.feat_cache = self.feat_cache.clone()
-        return self.decode_(x, self.feat_cache)
+        return self.decoder(x.squeeze(1), self.feat_cache).clone()
 
 class StreamingTAEHV(nn.Module):
     def __init__(self, taehv):

--- a/taehv.py
+++ b/taehv.py
@@ -321,32 +321,23 @@ class OptimizedDecoder(nn.Module):
 
         return opt
 
-    def forward(self, z, feat_cache):
+    #@torch.compile(mode='max-autotune', fullgraph=True)
+    def forward_(self, z, c00, c01, c02, c10, c11, c12, c20, c21, c22):
         # z is [1, c, h, w]
         x0 = self.dec_pre(z)
 
         # First stage
-        x1 = self.mb_00(feat_cache.get("00"), x0)
-        x2 = self.mb_01(feat_cache.get("01"), x1)
-        x3 = self.mb_02(feat_cache.get("02"), x2)
-
-        # Update cache
-        feat_cache.set("00", x0)
-        feat_cache.set("01", x1)
-        feat_cache.set("02", x2)
+        x1 = self.mb_00(c00, x0)
+        x2 = self.mb_01(c01, x1)
+        x3 = self.mb_02(c02, x2)
 
         # Upsample and project
         x4 = self.proj_0(self.t_up_0(self.up_0(x3)))
 
         # Second stage
-        x5 = self.mb_10(feat_cache.get("10"), x4)
-        x6 = self.mb_11(feat_cache.get("11"), x5)
-        x7 = self.mb_12(feat_cache.get("12"), x6)
-
-        # Update cache
-        feat_cache.set("10", x4)
-        feat_cache.set("11", x5)
-        feat_cache.set("12", x6)
+        x5 = self.mb_10(c10, x4)
+        x6 = self.mb_11(c11, x5)
+        x7 = self.mb_12(c12, x6)
 
         # Upsample and project
         x8 = self.up_1(x7)
@@ -355,14 +346,9 @@ class OptimizedDecoder(nn.Module):
         x9_next = self.proj_1(x8_next)
 
         # Third stage
-        x10_prev, x10_next = self.mb_20(feat_cache.get("20"), x9_prev, x9_next)
-        x11_prev, x11_next = self.mb_21(feat_cache.get("21"), x10_prev, x10_next)
-        x12_prev, x12_next = self.mb_22(feat_cache.get("22"), x11_prev, x11_next)
-
-        # Update cache
-        feat_cache.set("20", x9_next)
-        feat_cache.set("21", x10_next)
-        feat_cache.set("22", x11_next)
+        x10_prev, x10_next = self.mb_20(c20, x9_prev, x9_next)
+        x11_prev, x11_next = self.mb_21(c21, x10_prev, x10_next)
+        x12_prev, x12_next = self.mb_22(c22, x11_prev, x11_next)
 
         # Upsample and project
         x13_prev = self.up_2(x12_prev)
@@ -376,7 +362,29 @@ class OptimizedDecoder(nn.Module):
         y = self.proj_2(y)
         y = self.dec_post(y)
         y = F.pixel_shuffle(y, self.patch_size)
-        return y.clamp_(0, 1)
+        return y.clamp_(0, 1), x0, x1, x2, x4, x5, x6, x9_next, x10_next, x11_next
+
+    def forward(self, z, feat_cache):
+        c00 = feat_cache.get("00")
+        c01 = feat_cache.get("01")
+        c02 = feat_cache.get("02")
+        c10 = feat_cache.get("10")
+        c11 = feat_cache.get("11")
+        c12 = feat_cache.get("12")
+        c20 = feat_cache.get("20")
+        c21 = feat_cache.get("21")
+        c22 = feat_cache.get("22")
+        y, c00, c01, c02, c10, c11, c12, c20, c21, c22 = self.forward_(z, c00, c01, c02, c10, c11, c12, c20, c21, c22)
+        feat_cache.set("00", c00)
+        feat_cache.set("01", c01)
+        feat_cache.set("02", c02)
+        feat_cache.set("10", c10)
+        feat_cache.set("11", c11)
+        feat_cache.set("12", c12)
+        feat_cache.set("20", c20)
+        feat_cache.set("21", c21)
+        feat_cache.set("22", c22)
+        return y
 
 class TAEHV(nn.Module):
     def __init__(self, checkpoint_path="taehv.pth", encoder_time_downscale=(True, True, False), decoder_time_upscale=(False, True, True), decoder_space_upscale=(True, True, True), patch_size=1, latent_channels=16):

--- a/taehv.py
+++ b/taehv.py
@@ -228,6 +228,11 @@ class FeatCache:
     def set(self, key, value):
         self.cache[key] = value.clone()
 
+    def clone(self):
+        new = FeatCache(device=self.device, dtype=self.dtype, input_shape=(self.h, self.w))
+        new.cache = {k: v.clone() for k, v in self.cache.items()}
+        return new
+
 def cat_fwd_split(layer, x, y):
     z = torch.cat([x, y], 0)
     z = layer(z)
@@ -495,8 +500,12 @@ class StreamingOptDecoder(nn.Module):
         self.feat_cache.reset()
 
     #@torch.compile(mode='max-autotune', fullgraph=True)
-    def decode(self, x): # assumes x is [1,1,c,h,w]
-        return self.decoder(x.squeeze(1), self.feat_cache)
+    def decode_(self, x, feat_cache): # assumes x is [1,1,c,h,w]
+        return self.decoder(x.squeeze(1), feat_cache)
+
+    def decode(self, x):
+        #self.feat_cache = self.feat_cache.clone()
+        return self.decode_(x, self.feat_cache)
 
 class StreamingTAEHV(nn.Module):
     def __init__(self, taehv):

--- a/taehv.py
+++ b/taehv.py
@@ -504,7 +504,7 @@ class StreamingOptDecoder(nn.Module):
         return self.decoder(x.squeeze(1), feat_cache)
 
     def decode(self, x):
-        #self.feat_cache = self.feat_cache.clone()
+        self.feat_cache = self.feat_cache.clone()
         return self.decode_(x, self.feat_cache)
 
 class StreamingTAEHV(nn.Module):

--- a/taehv.py
+++ b/taehv.py
@@ -277,7 +277,7 @@ class OptimizedDecoder(nn.Module):
 
         Assumes the TAEHV decoder has decoder_time_upscale=(False, True, True) and
         decoder_space_upscale=(True, True, True), i.e. the taehv1_5 configuration.
-        The stride-1 TGrow at decoder[7] is dropped (it has no temporal effect).
+        The stride-1 TGrow at decoder[7] is a learned 1x1 projection (not a no-op).
 
         TAEHV decoder layout (indices):
           0:Clamp  1:conv  2:ReLU
@@ -294,7 +294,8 @@ class OptimizedDecoder(nn.Module):
         opt.mb_00.load_state_dict(dec[3].state_dict())
         opt.mb_01.load_state_dict(dec[4].state_dict())
         opt.mb_02.load_state_dict(dec[5].state_dict())
-        # dec[6] = Upsample (no params), dec[7] = TGrow(stride=1) (dropped)
+        # dec[6] = Upsample (no params)
+        opt.t_up_0.load_state_dict(dec[7].state_dict())       # TGrow(256, stride=1)
         opt.proj_0.load_state_dict(dec[8].state_dict())       # conv(256→128)
 
         opt.mb_10.load_state_dict(dec[9].state_dict())

--- a/test_decoder.py
+++ b/test_decoder.py
@@ -18,7 +18,8 @@ N_EVAL = 5
 taehv = TAEHV(checkpoint_path=CHECKPOINT).to(DEVICE, DTYPE)
 taehv.eval()
 streaming = StreamingTAEHV(taehv)
-opt_streaming = StreamingOptDecoder(taehv, device=DEVICE, dtype=DTYPE)
+opt_streaming = StreamingOptDecoder(taehv, device=DEVICE, dtype=DTYPE).to(DEVICE, DTYPE)
+opt_streaming.eval()
 
 
 def make_latents():

--- a/test_decoder.py
+++ b/test_decoder.py
@@ -76,21 +76,22 @@ def run():
                 torch.cuda.synchronize()
             elapsed = time.perf_counter() - t0
 
-        n_frames = len(frames)
-        fps = n_frames / elapsed
+        n_latents = latents.shape[1]
+        fps = n_latents / elapsed
+        latency = elapsed / n_latents
         fps_list.append(fps)
-        latency_list.append(elapsed)
+        latency_list.append(latency)
 
         if i == 0:
             ref_frames = frames  # save first run's output for deviation baseline
             ref_latents = latents
 
-        print(f"  Run {i+1}: {n_frames} frames in {elapsed:.3f}s → {fps:.1f} FPS")
+        print(f"  Run {i+1}: {n_latents} latents in {elapsed:.3f}s → {fps:.2f} latents/s, {latency*1000:.2f}ms/latent")
 
     avg_fps = sum(fps_list) / len(fps_list)
     avg_latency = sum(latency_list) / len(latency_list)
-    print(f"\nAverage FPS:     {avg_fps:.2f}")
-    print(f"Average latency: {avg_latency:.3f}s")
+    print(f"\nAverage latents/s: {avg_fps:.2f}")
+    print(f"Average latency:   {avg_latency*1000:.2f}ms/latent")
 
     # --- Deviation metric ---
     # Baseline: decode a fresh random latent, measure deviation from ref
@@ -114,8 +115,8 @@ def run():
     print(f"  A good optimized decoder should have deviation << {random_baseline:.4f} (random baseline).")
 
     return {
-        "avg_fps": avg_fps,
-        "avg_latency": avg_latency,
+        "avg_latents_per_sec": avg_fps,
+        "avg_latency_ms": avg_latency * 1000,
         "random_baseline_deviation": random_baseline,
         "ref_frames": ref_frames,
         "ref_latents": ref_latents,

--- a/test_decoder.py
+++ b/test_decoder.py
@@ -12,8 +12,8 @@ DTYPE = torch.float16
 
 N_LATENT_FRAMES = 16   # T dimension of latents
 LATENT_H, LATENT_W = 32, 64
-N_WARMUP = 2
-N_EVAL = 5
+N_WARMUP = 5
+N_EVAL = 20
 
 taehv = TAEHV(checkpoint_path=CHECKPOINT).to(DEVICE, DTYPE)
 taehv.eval()
@@ -101,9 +101,12 @@ def benchmark(decode_fn, label):
 
         print(f"  Run {i+1}: {n_latents} latents in {elapsed:.3f}s → {fps:.2f} latents/s, {latency*1000:.2f}ms/latent")
 
-    avg_fps = sum(fps_list) / len(fps_list)
-    avg_latency = sum(latency_list) / len(latency_list)
-    print(f"Average latents/s: {avg_fps:.2f}")
+    # skip first run in case of recompilation hit
+    stable_fps = fps_list[1:]
+    stable_latency = latency_list[1:]
+    avg_fps = sum(stable_fps) / len(stable_fps)
+    avg_latency = sum(stable_latency) / len(stable_latency)
+    print(f"Average latents/s: {avg_fps:.2f}  (runs 2-{N_EVAL}, excl. first)")
     print(f"Average latency:   {avg_latency*1000:.2f}ms/latent")
 
     return avg_fps, avg_latency, ref_frames, ref_latents

--- a/test_decoder.py
+++ b/test_decoder.py
@@ -64,7 +64,7 @@ def run():
     print(f"\nRunning {N_WARMUP} warmup calls...")
     for _ in range(N_WARMUP):
         latents = make_latents()
-        with torch.no_grad():
+        with torch.inference_mode():
             decode_streaming(latents)
 
     # --- Eval ---
@@ -75,7 +75,7 @@ def run():
 
     for i in range(N_EVAL):
         latents = make_latents()
-        with torch.no_grad():
+        with torch.inference_mode():
             t0 = time.perf_counter()
             frames = decode_streaming(latents)
             if DEVICE.type == "cuda":
@@ -102,7 +102,7 @@ def run():
     # --- Deviation metric ---
     # Baseline: decode a fresh random latent, measure deviation from ref
     print("\nComputing deviation metrics...")
-    with torch.no_grad():
+    with torch.inference_mode():
         random_latents = make_latents()
         random_frames = decode_streaming(random_latents)
 

--- a/test_decoder.py
+++ b/test_decoder.py
@@ -4,7 +4,7 @@ Usage: python test_decoder.py
 """
 import torch
 import time
-from taehv import TAEHV, StreamingTAEHV
+from taehv import TAEHV, StreamingTAEHV, StreamingOptDecoder
 
 CHECKPOINT = "taehv1_5.pth"
 DEVICE = torch.device("cuda" if torch.cuda.is_available() else "mps" if torch.backends.mps.is_available() else "cpu")
@@ -18,10 +18,7 @@ N_EVAL = 5
 taehv = TAEHV(checkpoint_path=CHECKPOINT).to(DEVICE, DTYPE)
 taehv.eval()
 streaming = StreamingTAEHV(taehv)
-
-# --- Compilation hook (optional) ---
-# Uncomment and modify to experiment with torch.compile:
-# streaming.decode = torch.compile(streaming.decode)
+opt_streaming = StreamingOptDecoder(taehv, device=DEVICE, dtype=DTYPE)
 
 
 def make_latents():
@@ -29,7 +26,7 @@ def make_latents():
 
 
 def decode_streaming(latents):
-    """Decode latents frame-by-frame using StreamingTAEHV. Returns list of decoded frames."""
+    """Decode latents using StreamingTAEHV. Returns list of N1CHW frames."""
     streaming.reset()
     frames = []
     for t in range(latents.shape[1]):
@@ -46,6 +43,19 @@ def decode_streaming(latents):
     return frames
 
 
+def decode_opt(latents):
+    """Decode latents using StreamingOptDecoder. Returns list of N4CHW frame chunks."""
+    opt_streaming.reset()
+    frames = []
+    for t in range(latents.shape[1]):
+        lat = latents[:, t:t+1]
+        chunk = opt_streaming.decode(lat)  # [4, C, H, W]
+        # split into individual frames to match streaming format
+        for i in range(chunk.shape[0]):
+            frames.append(chunk[i:i+1].unsqueeze(1))
+    return frames
+
+
 def compute_deviation(frames_a, frames_b):
     """Mean absolute deviation between two lists of N1CHW frames."""
     a = torch.cat(frames_a, dim=1).float()
@@ -53,31 +63,27 @@ def compute_deviation(frames_a, frames_b):
     return (a - b).abs().mean().item()
 
 
-def run():
-    print(f"Device: {DEVICE}, dtype: {DTYPE}, checkpoint: {CHECKPOINT}")
-    expected_frames = N_LATENT_FRAMES * taehv.t_upscale - taehv.frames_to_trim
+def benchmark(decode_fn, label):
+    print(f"\n--- {label} ---")
 
-    print(f"\nLatent shape: [1, {N_LATENT_FRAMES}, {taehv.latent_channels}, {LATENT_H}, {LATENT_W}]")
-    print(f"Expected output frames: {expected_frames}")
-
-    # --- Warmup ---
-    print(f"\nRunning {N_WARMUP} warmup calls...")
+    # Warmup
+    print(f"Running {N_WARMUP} warmup calls...")
     for _ in range(N_WARMUP):
-        latents = make_latents()
         with torch.inference_mode():
-            decode_streaming(latents)
+            decode_fn(make_latents())
 
-    # --- Eval ---
+    # Eval
     print(f"Running {N_EVAL} eval calls...")
     fps_list = []
     latency_list = []
     ref_frames = None
+    ref_latents = None
 
     for i in range(N_EVAL):
         latents = make_latents()
         with torch.inference_mode():
             t0 = time.perf_counter()
-            frames = decode_streaming(latents)
+            frames = decode_fn(latents)
             if DEVICE.type == "cuda":
                 torch.cuda.synchronize()
             elapsed = time.perf_counter() - t0
@@ -89,45 +95,50 @@ def run():
         latency_list.append(latency)
 
         if i == 0:
-            ref_frames = frames  # save first run's output for deviation baseline
+            ref_frames = frames
             ref_latents = latents
 
         print(f"  Run {i+1}: {n_latents} latents in {elapsed:.3f}s → {fps:.2f} latents/s, {latency*1000:.2f}ms/latent")
 
     avg_fps = sum(fps_list) / len(fps_list)
     avg_latency = sum(latency_list) / len(latency_list)
-    print(f"\nAverage latents/s: {avg_fps:.2f}")
+    print(f"Average latents/s: {avg_fps:.2f}")
     print(f"Average latency:   {avg_latency*1000:.2f}ms/latent")
 
-    # --- Deviation metric ---
-    # Baseline: decode a fresh random latent, measure deviation from ref
-    print("\nComputing deviation metrics...")
+    return avg_fps, avg_latency, ref_frames, ref_latents
+
+
+def run():
+    print(f"Device: {DEVICE}, dtype: {DTYPE}, checkpoint: {CHECKPOINT}")
+    print(f"Latent shape: [1, {N_LATENT_FRAMES}, {taehv.latent_channels}, {LATENT_H}, {LATENT_W}]")
+
+    ref_fps, ref_latency, ref_frames, ref_latents = benchmark(decode_streaming, "StreamingTAEHV (reference)")
+    opt_fps, opt_latency, opt_frames, _           = benchmark(lambda l: decode_opt(l), "StreamingOptDecoder")
+
+    # --- Deviation ---
+    print("\n--- Deviation Analysis ---")
     with torch.inference_mode():
-        random_latents = make_latents()
-        random_frames = decode_streaming(random_latents)
+        random_frames = decode_streaming(make_latents())
 
-    # Align lengths (in case of off-by-one from trimming)
-    n = min(len(ref_frames), len(random_frames))
-    ref_frames_trimmed = ref_frames[:n]
-    random_frames_trimmed = random_frames[:n]
-
-    random_baseline = compute_deviation(ref_frames_trimmed, random_frames_trimmed)
-    self_deviation = compute_deviation(ref_frames, ref_frames)  # sanity check: should be 0
+    n = min(len(ref_frames), len(random_frames), len(opt_frames))
+    random_baseline = compute_deviation(ref_frames[:n], random_frames[:n])
+    opt_deviation   = compute_deviation(ref_frames[:n], opt_frames[:n])
+    self_deviation  = compute_deviation(ref_frames[:n], ref_frames[:n])
 
     print(f"  Self-deviation (sanity, should be 0): {self_deviation:.6f}")
     print(f"  Random baseline deviation:            {random_baseline:.6f}")
+    print(f"  OptimizedDecoder deviation:           {opt_deviation:.6f}")
     print()
-    print("When testing OptimizedDecoder, compare its deviation against ref_frames.")
-    print(f"  A good optimized decoder should have deviation << {random_baseline:.4f} (random baseline).")
+    if opt_deviation < random_baseline * 0.1:
+        print("  OptimizedDecoder output looks correct (deviation << random baseline).")
+    else:
+        print("  WARNING: OptimizedDecoder deviation is close to random baseline — possible bug.")
 
-    return {
-        "avg_latents_per_sec": avg_fps,
-        "avg_latency_ms": avg_latency * 1000,
-        "random_baseline_deviation": random_baseline,
-        "ref_frames": ref_frames,
-        "ref_latents": ref_latents,
-    }
+    print("\n--- Summary ---")
+    print(f"  Reference:  {ref_fps:.2f} latents/s, {ref_latency*1000:.2f}ms/latent")
+    print(f"  Optimized:  {opt_fps:.2f} latents/s, {opt_latency*1000:.2f}ms/latent")
+    print(f"  Speedup:    {opt_fps/ref_fps:.2f}x")
 
 
 if __name__ == "__main__":
-    results = run()
+    run()

--- a/test_decoder.py
+++ b/test_decoder.py
@@ -117,20 +117,22 @@ def run():
     opt_fps, opt_latency, opt_frames, _           = benchmark(lambda l: decode_opt(l), "StreamingOptDecoder")
 
     # --- Deviation ---
+    # Decode the same latents with both decoders for a fair comparison
     print("\n--- Deviation Analysis ---")
     with torch.inference_mode():
-        random_frames = decode_streaming(make_latents())
+        random_frames   = decode_streaming(make_latents())
+        opt_same_frames = decode_opt(ref_latents)
 
     trim = taehv.frames_to_trim
-    opt_frames_trimmed = opt_frames[trim:]
-    n = min(len(ref_frames), len(random_frames), len(opt_frames_trimmed))
+    opt_same_trimmed = opt_same_frames[trim:]
+    n = min(len(ref_frames), len(random_frames), len(opt_same_trimmed))
     random_baseline = compute_deviation(ref_frames[:n], random_frames[:n])
-    opt_deviation   = compute_deviation(ref_frames[:n], opt_frames_trimmed[:n])
+    opt_deviation   = compute_deviation(ref_frames[:n], opt_same_trimmed[:n])
     self_deviation  = compute_deviation(ref_frames[:n], ref_frames[:n])
 
     print(f"  Self-deviation (sanity, should be 0): {self_deviation:.6f}")
     print(f"  Random baseline deviation:            {random_baseline:.6f}")
-    print(f"  OptimizedDecoder deviation:           {opt_deviation:.6f}")
+    print(f"  OptimizedDecoder deviation:           {opt_deviation:.6f}  (same latents as reference)")
     print()
     if opt_deviation < random_baseline * 0.1:
         print("  OptimizedDecoder output looks correct (deviation << random baseline).")

--- a/test_decoder.py
+++ b/test_decoder.py
@@ -1,0 +1,126 @@
+"""
+Test script for streaming decoder performance and correctness.
+Usage: python test_decoder.py
+"""
+import torch
+import time
+from taehv import TAEHV, StreamingTAEHV
+
+CHECKPOINT = "taehv1_5.pth"
+DEVICE = torch.device("cuda" if torch.cuda.is_available() else "mps" if torch.backends.mps.is_available() else "cpu")
+DTYPE = torch.float16
+
+N_LATENT_FRAMES = 16   # T dimension of latents
+LATENT_H, LATENT_W = 32, 64
+N_WARMUP = 2
+N_EVAL = 5
+
+
+def make_latents(taehv):
+    return torch.randn(1, N_LATENT_FRAMES, taehv.latent_channels, LATENT_H, LATENT_W, device=DEVICE, dtype=DTYPE)
+
+
+def decode_streaming(taehv, latents):
+    """Decode latents frame-by-frame using StreamingTAEHV. Returns list of decoded frames."""
+    streaming = StreamingTAEHV(taehv)
+    frames = []
+    for t in range(latents.shape[1]):
+        lat = latents[:, t:t+1]
+        frame = streaming.decode(lat)
+        if frame is not None:
+            frames.append(frame)
+        while True:
+            frame = streaming.decode()
+            if frame is None:
+                break
+            frames.append(frame)
+    frames.extend(streaming.flush_decoder())
+    return frames
+
+
+def compute_deviation(frames_a, frames_b):
+    """Mean absolute deviation between two lists of N1CHW frames."""
+    a = torch.cat(frames_a, dim=1).float()
+    b = torch.cat(frames_b, dim=1).float()
+    return (a - b).abs().mean().item()
+
+
+def run():
+    print(f"Device: {DEVICE}, dtype: {DTYPE}, checkpoint: {CHECKPOINT}")
+    taehv = TAEHV(checkpoint_path=CHECKPOINT).to(DEVICE, DTYPE)
+    taehv.eval()
+    expected_frames = N_LATENT_FRAMES * taehv.t_upscale - taehv.frames_to_trim
+
+    print(f"\nLatent shape: [1, {N_LATENT_FRAMES}, {taehv.latent_channels}, {LATENT_H}, {LATENT_W}]")
+    print(f"Expected output frames: {expected_frames}")
+
+    # --- Warmup ---
+    print(f"\nRunning {N_WARMUP} warmup calls...")
+    for _ in range(N_WARMUP):
+        latents = make_latents(taehv)
+        with torch.no_grad():
+            decode_streaming(taehv, latents)
+
+    # --- Eval ---
+    print(f"Running {N_EVAL} eval calls...")
+    fps_list = []
+    latency_list = []
+    ref_frames = None
+
+    for i in range(N_EVAL):
+        latents = make_latents(taehv)
+        with torch.no_grad():
+            t0 = time.perf_counter()
+            frames = decode_streaming(taehv, latents)
+            if DEVICE.type == "cuda":
+                torch.cuda.synchronize()
+            elapsed = time.perf_counter() - t0
+
+        n_frames = len(frames)
+        fps = n_frames / elapsed
+        fps_list.append(fps)
+        latency_list.append(elapsed)
+
+        if i == 0:
+            ref_frames = frames  # save first run's output for deviation baseline
+            ref_latents = latents
+
+        print(f"  Run {i+1}: {n_frames} frames in {elapsed:.3f}s → {fps:.1f} FPS")
+
+    avg_fps = sum(fps_list) / len(fps_list)
+    avg_latency = sum(latency_list) / len(latency_list)
+    print(f"\nAverage FPS:     {avg_fps:.2f}")
+    print(f"Average latency: {avg_latency:.3f}s")
+
+    # --- Deviation metric ---
+    # Baseline: decode a fresh random latent, measure deviation from ref
+    print("\nComputing deviation metrics...")
+    with torch.no_grad():
+        random_latents = make_latents(taehv)
+        random_frames = decode_streaming(taehv, random_latents)
+
+    # Align lengths (in case of off-by-one from trimming)
+    n = min(len(ref_frames), len(random_frames))
+    ref_frames_trimmed = ref_frames[:n]
+    random_frames_trimmed = random_frames[:n]
+
+    random_baseline = compute_deviation(ref_frames_trimmed, random_frames_trimmed)
+    self_deviation = compute_deviation(ref_frames, ref_frames)  # sanity check: should be 0
+
+    print(f"  Self-deviation (sanity, should be 0): {self_deviation:.6f}")
+    print(f"  Random baseline deviation:            {random_baseline:.6f}")
+    print()
+    print("When testing OptimizedDecoder, compare its deviation against ref_frames.")
+    print(f"  A good optimized decoder should have deviation << {random_baseline:.4f} (random baseline).")
+
+    return {
+        "avg_fps": avg_fps,
+        "avg_latency": avg_latency,
+        "random_baseline_deviation": random_baseline,
+        "ref_frames": ref_frames,
+        "ref_latents": ref_latents,
+    }
+
+
+if __name__ == "__main__":
+    results = run()

--- a/test_decoder.py
+++ b/test_decoder.py
@@ -15,14 +15,22 @@ LATENT_H, LATENT_W = 32, 64
 N_WARMUP = 2
 N_EVAL = 5
 
+taehv = TAEHV(checkpoint_path=CHECKPOINT).to(DEVICE, DTYPE)
+taehv.eval()
+streaming = StreamingTAEHV(taehv)
 
-def make_latents(taehv):
+# --- Compilation hook (optional) ---
+# Uncomment and modify to experiment with torch.compile:
+# streaming.decode = torch.compile(streaming.decode)
+
+
+def make_latents():
     return torch.randn(1, N_LATENT_FRAMES, taehv.latent_channels, LATENT_H, LATENT_W, device=DEVICE, dtype=DTYPE)
 
 
-def decode_streaming(taehv, latents):
+def decode_streaming(latents):
     """Decode latents frame-by-frame using StreamingTAEHV. Returns list of decoded frames."""
-    streaming = StreamingTAEHV(taehv)
+    streaming.reset()
     frames = []
     for t in range(latents.shape[1]):
         lat = latents[:, t:t+1]
@@ -47,8 +55,6 @@ def compute_deviation(frames_a, frames_b):
 
 def run():
     print(f"Device: {DEVICE}, dtype: {DTYPE}, checkpoint: {CHECKPOINT}")
-    taehv = TAEHV(checkpoint_path=CHECKPOINT).to(DEVICE, DTYPE)
-    taehv.eval()
     expected_frames = N_LATENT_FRAMES * taehv.t_upscale - taehv.frames_to_trim
 
     print(f"\nLatent shape: [1, {N_LATENT_FRAMES}, {taehv.latent_channels}, {LATENT_H}, {LATENT_W}]")
@@ -57,9 +63,9 @@ def run():
     # --- Warmup ---
     print(f"\nRunning {N_WARMUP} warmup calls...")
     for _ in range(N_WARMUP):
-        latents = make_latents(taehv)
+        latents = make_latents()
         with torch.no_grad():
-            decode_streaming(taehv, latents)
+            decode_streaming(latents)
 
     # --- Eval ---
     print(f"Running {N_EVAL} eval calls...")
@@ -68,10 +74,10 @@ def run():
     ref_frames = None
 
     for i in range(N_EVAL):
-        latents = make_latents(taehv)
+        latents = make_latents()
         with torch.no_grad():
             t0 = time.perf_counter()
-            frames = decode_streaming(taehv, latents)
+            frames = decode_streaming(latents)
             if DEVICE.type == "cuda":
                 torch.cuda.synchronize()
             elapsed = time.perf_counter() - t0
@@ -97,8 +103,8 @@ def run():
     # Baseline: decode a fresh random latent, measure deviation from ref
     print("\nComputing deviation metrics...")
     with torch.no_grad():
-        random_latents = make_latents(taehv)
-        random_frames = decode_streaming(taehv, random_latents)
+        random_latents = make_latents()
+        random_frames = decode_streaming(random_latents)
 
     # Align lengths (in case of off-by-one from trimming)
     n = min(len(ref_frames), len(random_frames))

--- a/test_decoder.py
+++ b/test_decoder.py
@@ -120,9 +120,11 @@ def run():
     with torch.inference_mode():
         random_frames = decode_streaming(make_latents())
 
-    n = min(len(ref_frames), len(random_frames), len(opt_frames))
+    trim = taehv.frames_to_trim
+    opt_frames_trimmed = opt_frames[trim:]
+    n = min(len(ref_frames), len(random_frames), len(opt_frames_trimmed))
     random_baseline = compute_deviation(ref_frames[:n], random_frames[:n])
-    opt_deviation   = compute_deviation(ref_frames[:n], opt_frames[:n])
+    opt_deviation   = compute_deviation(ref_frames[:n], opt_frames_trimmed[:n])
     self_deviation  = compute_deviation(ref_frames[:n], ref_frames[:n])
 
     print(f"  Self-deviation (sanity, should be 0): {self_deviation:.6f}")

--- a/validate_opt_decoder.py
+++ b/validate_opt_decoder.py
@@ -1,0 +1,87 @@
+"""
+Validate OptimizedDecoder on a real latent file, saving output to test.mp4.
+"""
+import torch
+import cv2
+from tqdm.auto import tqdm
+from taehv import TAEHV, StreamingOptDecoder
+
+CHECKPOINT    = "taehv1_5.pth"
+LATENT_PATH   = "/mnt/data/waypoint1_5/encoded/owl_control/720p/0000bd48604141b4/taehv1_5/000000_latent.pt"
+OUTPUT_PATH   = "test.mp4"
+N_LATENTS     = 256   # take first N latent frames
+FPS           = 60
+
+DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+DTYPE  = torch.float16
+
+
+def main():
+    # --- Load model ---
+    print(f"Loading TAEHV from {CHECKPOINT}...")
+    taehv = TAEHV(checkpoint_path=CHECKPOINT).to(DEVICE, DTYPE)
+    taehv.eval()
+
+    # --- Load latent ---
+    print(f"Loading latent from {LATENT_PATH}...")
+    latent = torch.load(LATENT_PATH, map_location="cpu", weights_only=True)
+    print(f"  Full latent shape: {latent.shape}")
+
+    latent = latent[:N_LATENTS]  # [T, C, H, W]
+    latent = latent.to(DEVICE, DTYPE)
+    T, C, H, W = latent.shape
+    print(f"  Using first {T} latent frames, shape {latent.shape}")
+
+    # spatial dims of the latent determine FeatCache input_shape
+    input_shape = (H, W)
+
+    # --- Build streaming decoder ---
+    streaming = StreamingOptDecoder(taehv, device=DEVICE, dtype=DTYPE, input_shape=input_shape).to(DEVICE, DTYPE)
+    streaming.decoder.eval()
+
+    # frames_to_trim matches TAEHV convention (t_upscale - 1)
+    frames_to_trim = taehv.frames_to_trim
+    frames_per_latent = taehv.t_upscale  # 4 for taehv1_5
+    print(f"  t_upscale={frames_per_latent}, frames_to_trim={frames_to_trim}")
+
+    # --- Decode ---
+    writer = None
+    frames_written = 0
+    frames_skipped = 0
+
+    with torch.no_grad():
+        for t in tqdm(range(T), desc="Decoding latents"):
+            x = latent[t].unsqueeze(0).unsqueeze(0)  # [1, 1, C, H, W]
+            out = streaming.decode(x)                 # [frames_per_latent, 3, H_out, W_out]
+
+            for frame_idx in range(out.shape[0]):
+                if frames_skipped < frames_to_trim:
+                    frames_skipped += 1
+                    continue
+
+                frame = out[frame_idx]  # [3, H_out, W_out], float in [0,1]
+                frame_np = (frame.float().permute(1, 2, 0).cpu().numpy() * 255).round().clip(0, 255).astype("uint8")
+                frame_bgr = cv2.cvtColor(frame_np, cv2.COLOR_RGB2BGR)
+
+                frame_bgr = cv2.resize(frame_bgr, (1280, 720), interpolation=cv2.INTER_LINEAR)
+
+                if writer is None:
+                    writer = cv2.VideoWriter(
+                        OUTPUT_PATH,
+                        cv2.VideoWriter_fourcc(*"mp4v"),
+                        FPS,
+                        (1280, 720),
+                    )
+
+                writer.write(frame_bgr)
+                frames_written += 1
+
+    if writer is not None:
+        writer.release()
+
+    print(f"\nDone. Wrote {frames_written} frames to {OUTPUT_PATH}")
+    print(f"  (skipped {frames_skipped} startup frames)")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
As context, I don't expect/want this PR to be directly merged in, as it's hard coded for taehv 1.5 and will not work for any of the other autoencoders. It is also decoder only.  
I'm hoping this work may be useful to others working on optimization downstream.  

Highlighted changes:  
`taehv.py`: see `OptMemBlock1x`, `OptMemBlock2x`, `OptTGrow`, `OptimizedDecoder`, `StreamingOptDecoder`  

`test_decoder.py`: Compares baseline streaming decoder output and throughput to optimized decoder given random input. Output of this is given further below.     

`validate_opt_decoder.py`: Runs decode on a latent tensor file and saves the resultant video in 720p60fps to test validity.    

  
Currently the codebase is not very friendly to compilation because of control flow resulting from the queue system. This system is necessary for full functionality. However, in the streaming use-case, many simplifying assumptions can be made that allow one to do away with the queue system entirely. Doing this enables max-autotune compilation and provides a 2x speedup when tested on an H200. Here is the output from `test_decoder.py`:

```
--- StreamingTAEHV (reference) ---                                                                                                                                                                                                                   
Running 5 warmup calls...                                                                                                                                                                                                                            
Running 20 eval calls...                                                                                                                                                                                                                             
  Run 1: 16 latents in 0.042s → 385.32 latents/s, 2.60ms/latent                                                                                                                                                                                      
  Run 2: 16 latents in 0.045s → 355.31 latents/s, 2.81ms/latent                                                                                                                                                                                      
  Run 3: 16 latents in 0.073s → 219.15 latents/s, 4.56ms/latent                                                                                                                                                                                      
...                                                                                                                                                                                  
  Run 18: 16 latents in 0.043s → 376.44 latents/s, 2.66ms/latent                                                                                                                                                                                     
  Run 19: 16 latents in 0.043s → 376.26 latents/s, 2.66ms/latent                                                                                                                                                                                     
  Run 20: 16 latents in 0.045s → 354.60 latents/s, 2.82ms/latent                                                                                                                                                                                     
Average latents/s: 372.83  (runs 2-20, excl. first)                                                                                                                                                                                                  
Average latency:   2.73ms/latent                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                     
--- StreamingOptDecoder ---                                                                                                                                                                                                                          
Running 5 warmup calls...                                                                                                                                                                                                                            
Running 20 eval calls...                                                                                                                                                                                                                             
  Run 1: 16 latents in 2.854s → 5.61 latents/s, 178.37ms/latent                                                                                                                                                                                      
  Run 2: 16 latents in 0.023s → 699.57 latents/s, 1.43ms/latent                                                                                                                                                                                      
  Run 3: 16 latents in 0.025s → 638.39 latents/s, 1.57ms/latent                                                                                                                                                                                      
...                                                                                                                                                                                                                                                                                                                                                                 
  Run 18: 16 latents in 0.020s → 782.17 latents/s, 1.28ms/latent                                                                                                                                                                                     
  Run 19: 16 latents in 0.020s → 782.93 latents/s, 1.28ms/latent                                                                                                                                                                                     
  Run 20: 16 latents in 0.020s → 783.62 latents/s, 1.28ms/latent                                                                                                                                                                                     
Average latents/s: 769.85  (runs 2-20, excl. first)                                                                                                                                                                                                  
Average latency:   1.30ms/latent                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                     
--- Deviation Analysis ---                                                                                                                                                                                                                           
  Self-deviation (sanity, should be 0): 0.000000                                                                                                                                                                                                     
  Random baseline deviation:            0.182813                                                                                                                                                                                                     
  OptimizedDecoder deviation:           0.000279  (same latents as reference)                                                                                                                                                                        
                                                                                                                                                                                                                                                     
  OptimizedDecoder output looks correct (deviation << random baseline).                                                                                                                                                                              
                                                                                                                                                                                                                                                     
--- Summary ---                                                                                                                                                                                                                                      
  Reference:  372.83 latents/s, 2.73ms/latent                                                                                                                                                                                                        
  Optimized:  769.85 latents/s, 1.30ms/latent                                                                                                                                                                                                        
  Speedup:    2.06x   
  ```

Note that when compilation is disabled, deviation is reduced to `0.000000` (i.e. the model is identical).
Here is a link to a decoded sample:
https://streamable.com/4s29lu

On the AI code: Implementation of the optimized decoder was human written, testing code and validation script were vibe coded, but values and output video were checked by a real human (me). Claude enthusiastically added himself as an author and I see no issue with this.  
  
Also I apologize in advance for the commit messages.
